### PR TITLE
Apply default NetworkPolicies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
-- …
+- Application of default NetworkPolicies ([#1])
 
-[Unreleased]: https://github.com/projectsyn/component-networkpolicy/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/projectsyn/component-networkpolicy/compare/dba1d0f...HEAD
+[#1]: https://github.com/projectsyn/component-networkpolicy/pull/1

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,15 @@ YAMLLINT_CONFIG ?= .yamllint.yml
 YAMLLINT_IMAGE  ?= docker.io/cytopia/yamllint:latest
 YAMLLINT_DOCKER ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(YAMLLINT_IMAGE)
 
+VALE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) --volume "$${PWD}"/docs/modules:/pages vshn/vale:2.1.1
+VALE_ARGS ?= --minAlertLevel=error --config=/pages/ROOT/pages/.vale.ini /pages
+
+
 .PHONY: all
 all: lint
 
 .PHONY: lint
-lint: lint_jsonnet lint_yaml
+lint: lint_jsonnet lint_yaml lint_adoc
 
 .PHONY: lint_jsonnet
 lint_jsonnet: $(JSONNET_FILES)
@@ -32,6 +36,10 @@ lint_jsonnet: $(JSONNET_FILES)
 .PHONY: lint_yaml
 lint_yaml: $(YAML_FILES)
 	$(YAMLLINT_DOCKER) -f parsable -c $(YAMLLINT_CONFIG) $(YAMLLINT_ARGS) -- $?
+
+.PHONY: lint_adoc
+lint_adoc:
+	$(VALE_CMD) $(VALE_ARGS)
 
 .PHONY: format
 format: format_jsonnet

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,3 +1,3 @@
 parameters:
   networkpolicy:
-    namespace: syn-networkpolicy
+    allowNamespaceLabels: []

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,3 +1,4 @@
 parameters:
   networkpolicy:
     allowNamespaceLabels: []
+    ignoredNamespaces: []

--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -3,8 +3,8 @@ local inv = kap.inventory();
 local params = inv.parameters.networkpolicy;
 local argocd = import 'lib/argocd.libjsonnet';
 
-local app = argocd.App('networkpolicy', params.namespace);
+local app = argocd.App('networkpolicy', 'syn');
 
 {
-  'networkpolicy': app,
+  networkpolicy: app,
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -60,12 +60,12 @@ local pruneConfig = espejo.syncConfig('networkpolicies-prune-ignored') {
     },
     deleteItems: [
       {
-        apiVersion: 'networking.k8s.io/v1',
-        kind: 'NetworkPolicy',
-        name: name,
+        apiVersion: policy.apiVersion,
+        kind: policy.kind,
+        name: policy.metadata.name,
 
       }
-      for name in ['allow-from-other-namespaces', 'allow-from-same-namespace']
+      for policy in syncConfig.spec.syncItems
     ],
   },
 };

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -56,7 +56,9 @@ local syncConfig = espejo.syncConfig('networkpolicies-default') {
 local pruneConfig = espejo.syncConfig('networkpolicies-prune-ignored') {
   spec: {
     namespaceSelector: {
-      matchNames: params.ignoredNamespaces,
+      labelSelector: {
+        'espejo.syn.tools/purge-network-policies': 'true',
+      },
     },
     deleteItems: [
       {
@@ -75,6 +77,7 @@ local labelPatches = std.flattenArrays([
     metadata: {
       labels: {
         'espejo.syn.tools/no-network-policies': 'true',
+        'espejo.syn.tools/purge-network-policies': 'true',
       },
     },
   })

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -59,7 +59,9 @@ local purgeConfig = espejo.syncConfig('networkpolicies-purge-defaults') {
   spec: {
     namespaceSelector: {
       labelSelector: {
-        [labelPurgeDefaults]: 'true',
+        matchLabels: {
+          [labelPurgeDefaults]: 'true',
+        },
       },
     },
     deleteItems: [{

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -1,10 +1,58 @@
 // main template for networkpolicy
+local espejo = import 'lib/espejo.libsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
 local inv = kap.inventory();
-// The hiera parameters for the component
+
 local params = inv.parameters.networkpolicy;
+local allowLabels = params.allowNamespaceLabels;
+
+local allowOthers = kube.NetworkPolicy('allow-from-other-namespaces') {
+  spec+: {
+    ingress+: [{
+      from: [
+        {
+          namespaceSelector: {
+            matchLabels: {
+              [key]: labels[key]
+              for key in std.objectFields(labels)
+            },
+          },
+        }
+        for labels in allowLabels
+      ],
+    }],
+  },
+};
+
+local allowSameNamespace = kube.NetworkPolicy('allow-from-same-namespace') {
+  spec+: {
+    ingress: [{
+      from: [{
+        podSelector: {},
+      }],
+    }],
+  },
+};
+
+local syncConfig = espejo.syncConfig('networkpolicies-default') {
+  spec: {
+    namespaceSelector: {
+      labelSelector: {
+        matchExpressions: [
+          {
+            key: 'espejo.syn.tools/no-network-policies',
+            operator: 'DoesNotExist',
+          },
+        ],
+      },
+    },
+    syncItems: [allowSameNamespace] +
+               if std.length(allowLabels) > 0 then [allowOthers] else [],
+  },
+};
 
 // Define outputs below
 {
+  networkpolicies: syncConfig,
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -52,7 +52,26 @@ local syncConfig = espejo.syncConfig('networkpolicies-default') {
   },
 };
 
+local pruneConfig = espejo.syncConfig('networkpolicies-prune-ignored') {
+  spec: {
+    namespaceSelector: {
+      matchNames: params.ignoredNamespaces,
+    },
+    deleteItems: [
+      {
+        apiVersion: 'networking.k8s.io/v1',
+        kind: 'NetworkPolicy',
+        name: name,
+
+      }
+      for name in ['allow-from-other-namespaces', 'allow-from-same-namespace']
+    ],
+  },
+};
+
+
 // Define outputs below
 {
-  networkpolicies: syncConfig,
+  [if std.length(params.ignoredNamespaces) > 0 then '05_prune']: pruneConfig,
+  '10_networkpolicies': syncConfig,
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -8,6 +8,9 @@ local inv = kap.inventory();
 local params = inv.parameters.networkpolicy;
 local allowLabels = params.allowNamespaceLabels;
 
+local labelNoDefaults = 'network-policies.syn.tools/no-defaults';
+local labelPurgeDefaults = 'network-policies.syn.tools/purge-purge';
+
 local allowOthers = kube.NetworkPolicy('allow-from-other-namespaces') {
   spec+: {
     ingress+: [{
@@ -42,7 +45,7 @@ local syncConfig = espejo.syncConfig('networkpolicies-default') {
       labelSelector: {
         matchExpressions: [
           {
-            key: 'espejo.syn.tools/no-network-policies',
+            key: labelNoDefaults,
             operator: 'DoesNotExist',
           },
         ],
@@ -57,7 +60,7 @@ local pruneConfig = espejo.syncConfig('networkpolicies-prune-ignored') {
   spec: {
     namespaceSelector: {
       labelSelector: {
-        'espejo.syn.tools/purge-network-policies': 'true',
+        [labelPurgeDefaults]: 'true',
       },
     },
     deleteItems: [
@@ -76,8 +79,8 @@ local labelPatches = std.flattenArrays([
   resourcelocker.Patch(kube.Namespace(ns), {
     metadata: {
       labels: {
-        'espejo.syn.tools/no-network-policies': 'true',
-        'espejo.syn.tools/purge-network-policies': 'true',
+        [labelNoDefaults]: 'true',
+        [labelPurgeDefaults]: 'true',
       },
     },
   })

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,3 +1,34 @@
 = NetworkPolicy: A Commodore component to manage NetworkPolicy
 
-{doctitle} is a Commodore component for Managing NetworkPolicy.
+{doctitle} provides the tooling to manage a set of NetworkPolicies in all the namespaces on a cluster.
+The intention is to create a safe default.
+This is done by isolating the network of a namespace.
+The created policies will allow only traffic from pods within the same network.
+They will also allow traffic from selected namespaces.
+The later is needed for ingress and monitoring to work.
+
+This component assumes, that a cluster was set up with a SDN that supports NetworkPolicies.
+
+An Espejo SyncConfig is used to create the policies.
+The SyncConfig is configured to ignore namespaces having the label `espejo.syn.tools/no-network-policies` (the value does not matter).
+
+[IMPORTANT]
+====
+The content of the created NetworkPolicies is enforced.
+Changes from other sources will be overwritten.
+If changes to the default policies are required, add the ignore label and create them on your own.
+====
+
+This component also allows to exclude a set of namespaces.
+Those namespaces will receive the `espejo.syn.tools/no-network-policies=true` label.
+The default NetworkPolicies will also be actively removed from those namespaces.
+
+[CAUTION]
+====
+Removing the NetworkPolicies from excluded namespaces is done by name.
+The names removed are `allow-from-same-namespace` and `allow-from-other-namespaces`.
+If similar rules are created in those namespaces, they must have different names.
+Otherwise, they will be removed.
+====
+
+See also the xref:references/parameters.adoc[parameters reference].

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -10,7 +10,7 @@ The latter is needed for ingress and monitoring to work.
 This component assumes that a cluster was set up with a https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins[network plugin] that supports NetworkPolicies.
 
 An Espejo SyncConfig is used to create the policies.
-The SyncConfig is configured to ignore namespaces having the label `espejo.syn.tools/no-network-policies` (the value does not matter).
+The SyncConfig is configured to ignore namespaces having the label `network-policies.syn.tools/no-defaults` (the value does not matter).
 
 [IMPORTANT]
 ====
@@ -20,12 +20,13 @@ If changes to the default policies are required, add the ignore label and create
 ====
 
 This component also allows to exclude a set of namespaces.
-Those namespaces will receive the `espejo.syn.tools/no-network-policies=true` label.
-The default NetworkPolicies will also be actively removed from those namespaces.
+Those namespaces will receive the `network-policies.syn.tools/no-defaults=true` and `network-policies.syn.tools/purge-defaults=true` labels.
+
+The label `network-policies.syn.tools/purge-defaults=true` results in the active removal of those default policies.
 
 [CAUTION]
 ====
-Removing the NetworkPolicies from excluded namespaces is done by name.
+Removing the NetworkPolicies from namespaces labeled `network-policies.syn.tools/purge-defaults=true` is done by name.
 The names removed are `allow-from-same-namespace` and `allow-from-other-namespaces`.
 If similar rules are created in those namespaces, they must have different names.
 Otherwise, they will be removed.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -10,7 +10,7 @@ The latter is needed for ingress and monitoring to work.
 This component assumes that a cluster was set up with a https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins[network plugin] that supports NetworkPolicies.
 
 An Espejo SyncConfig is used to create the policies.
-The SyncConfig is configured to ignore namespaces having the label `network-policies.syn.tools/no-defaults` (the value does not matter).
+The SyncConfig is configured to ignore namespaces having the label `network-policies.syn.tools/no-defaults` (the value doesn't matter).
 
 [IMPORTANT]
 ====

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -5,9 +5,9 @@ The intention is to create a safe default.
 This is done by isolating the network of a namespace.
 The created policies will allow only traffic from pods within the same network.
 They will also allow traffic from selected namespaces.
-The later is needed for ingress and monitoring to work.
+The latter is needed for ingress and monitoring to work.
 
-This component assumes, that a cluster was set up with a SDN that supports NetworkPolicies.
+This component assumes that a cluster was set up with a https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins[network plugin] that supports NetworkPolicies.
 
 An Espejo SyncConfig is used to create the policies.
 The SyncConfig is configured to ignore namespaces having the label `espejo.syn.tools/no-network-policies` (the value does not matter).

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -32,7 +32,7 @@ default:: empty list
 
 A list of namespace names where no default NetworkPolicies will be created.
 All namespaces in this list will receive the label `espejo.syn.tools/no-network-policies=true`.
-Default NetworkPolicies will also be activly removed from thos namesapces.
+Default NetworkPolicies will also be actively removed from those namespaces.
 
 [NOTE]
 ====

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -31,14 +31,7 @@ type:: list of strings
 default:: empty list
 
 A list of namespace names where no default NetworkPolicies will be created.
-All namespaces in this list will receive the label `espejo.syn.tools/no-network-policies=true`.
-Default NetworkPolicies will also be actively removed from those namespaces.
-
-[NOTE]
-====
-The removal of the NetworkPolcies is done based on the namespace names.
-The label `espejo.syn.tools/no-network-policies` controlls only the creation of them.
-====
+All namespaces in this list will receive the labels `network-policies.syn.tools/no-defaults=true` and `network-policies.syn.tools/purge-defaults=true`
 
 == Example
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -1,0 +1,57 @@
+= Parameters
+
+The parent key for all of the following parameters is `networkpolicy`.
+
+== `allowNamespaceLabels`
+
+[horizontal]
+type:: list of tuples
+default:: empty list
+
+A list of labels matching namespaces to allow traffic from.
+Each list item can contain several key value pairs.
+They result in an `AND` condition.
+Individual list iems will result in an `OR` condtion.
+
+[source,yaml]
+----
+allowNamespaceLabels:
+  - my-label-a: true
+    my-label-b: true
+  - my-label-c: true
+----
+
+In the above example, traffic will be allowed if a namespaces has the label `my-lable-a=true` AND `my-label-b=true`.
+Trafic will also be allowed if a namespce is labeled `my-label-c`.
+
+== `ignoredNamespaces`
+
+[horizontal]
+type:: list of strings
+default:: empty list
+
+A list of namespace names where no default NetworkPolicies will be created.
+All namespaces in this list will receive the label `espejo.syn.tools/no-network-policies=true`.
+Default NetworkPolicies will also be activly removed from thos namesapces.
+
+[NOTE]
+====
+The removal of the NetworkPolcies is done based on the namespace names.
+The label `espejo.syn.tools/no-network-policies` controlls only the creation of them.
+====
+
+== Example
+
+[source,yaml]
+----
+# Allow trafic from ingress and monitoring
+allowNamespaceLabels:
+  - network.openshift.io/policy-group: monitoring
+  - network.openshift.io/policy-group: ingress
+# Do not create the default policies in the OpenShift namespaces.
+ignoredNamespaces:
+  - openshift
+  - openshift-apiserver
+  - openshift-apiserver-operator
+  - …
+----

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -1,1 +1,2 @@
 * xref:index.adoc[Home]
+xref:references/parameters.adoc[Parameters]

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,5 +1,5 @@
 site:
-  title: "NetworkPolicy"
+  title: NetworkPolicy
   url: https://syn.tools/
   start_page: networkpolicy::index.adoc
   robots: disallow
@@ -11,7 +11,7 @@ content:
       edit_url: 'https://github.com/projectsyn/component-networkpolicy/edit/master/{path}'
 ui:
   bundle:
-    url: https://github.com/vshn/antora-ui-default/releases/download/1.6/ui-bundle.zip
+    url: https://github.com/projectsyn/antora-ui-default/releases/download/1.3/ui-bundle.zip
     snapshot: false
 asciidoc:
   attributes:


### PR DESCRIPTION
Apply a set of default NetworkPolcies to isolate namespaces from each other.
Traffic from a configurable set other namespaces are also allowed.

The implementation also allows to ignore a given set of namespaces and a label can be used to prevent those policies from being created.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
