### PR TITLE
Add metadata to sync items in SyncConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v1.0.0]
 ### Added
 
 - Application of default NetworkPolicies ([#1])
 - Expose labels as parameters ([#2])
+- Added more metadata to generated SyncConfigs and their sync objects ([#5])
 
 ### Changed
 
 - Disable Kapitan plugin ([#3])
 
-[Unreleased]: https://github.com/projectsyn/component-networkpolicy/compare/dba1d0f...HEAD
+[Unreleased]: https://github.com/projectsyn/component-networkpolicy/compare/v1.0.0...HEAD
+[v1.0.0]: https://github.com/projectsyn/component-networkpolicy/releases/tag/v1.0.0
 [#1]: https://github.com/projectsyn/component-networkpolicy/pull/1
 [#2]: https://github.com/projectsyn/component-networkpolicy/pull/2
 [#3]: https://github.com/projectsyn/component-networkpolicy/pull/3
+[#5]: https://github.com/projectsyn/component-networkpolicy/pull/5

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -7,7 +7,26 @@ local inv = kap.inventory();
 local params = inv.parameters.networkpolicy;
 local allowLabels = params.allowNamespaceLabels;
 
+local commonAnnotations = {
+  'syn.tools/source': 'https://github.com/projectsyn/component-networkpolicy.git',
+};
+
+local commonItemLabels = {
+  'app.kubernetes.io/managed-by': 'espejo',
+  'app.kubernetes.io/part-of': 'syn',
+  'app.kubernetes.io/component': 'networkpolicy',
+};
+
+local commonSyncLabels = {
+  'app.kubernetes.io/part-of': 'syn',
+  'app.kubernetes.io/component': 'networkpolicy',
+};
+
 local allowOthers = kube.NetworkPolicy('allow-from-other-namespaces') {
+  metadata+: {
+    annotations+: commonAnnotations,
+    labels+: commonItemLabels,
+  },
   spec+: {
     ingress+: [{
       from: [
@@ -26,6 +45,10 @@ local allowOthers = kube.NetworkPolicy('allow-from-other-namespaces') {
 };
 
 local allowSameNamespace = kube.NetworkPolicy('allow-from-same-namespace') {
+  metadata+: {
+    annotations+: commonAnnotations,
+    labels+: commonItemLabels,
+  },
   spec+: {
     ingress: [{
       from: [{
@@ -36,6 +59,10 @@ local allowSameNamespace = kube.NetworkPolicy('allow-from-same-namespace') {
 };
 
 local syncConfig = espejo.syncConfig('networkpolicies-default') {
+  metadata+: {
+    annotations+: commonAnnotations,
+    labels+: commonSyncLabels,
+  },
   spec: {
     namespaceSelector: {
       labelSelector: {
@@ -53,6 +80,10 @@ local syncConfig = espejo.syncConfig('networkpolicies-default') {
 };
 
 local purgeConfig = espejo.syncConfig('networkpolicies-purge-defaults') {
+  metadata+: {
+    annotations+: commonAnnotations,
+    labels+: commonSyncLabels,
+  },
   spec: {
     namespaceSelector: {
       labelSelector: {


### PR DESCRIPTION
`kube.NetworkPolicy` creates an object with empty `metadata.annotations: {}`.
This causes a problem when ArgoCD tries to create a SyncConfig spec with that,
but Espejo removes the empty Annotation field when updating its status.

Thus ArgoCD is always OutOfSync.

This can be fixed by either removing the field, or by adding metadata in form of annotations.

Fixes https://github.com/vshn/espejo/issues/102

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
