### PR TITLE
Omit empty `spec.egress` in the managed network policies

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -40,6 +40,8 @@ local allowOthers = kube.NetworkPolicy('allow-from-other-namespaces') {
         for labels in allowLabels
       ],
     } ],
+    // Hide unused optional egress field
+    egress:: [],
   },
 };
 
@@ -54,6 +56,8 @@ local allowSameNamespace = kube.NetworkPolicy('allow-from-same-namespace') {
         podSelector: {},
       } ],
     } ],
+    // Hide unused optional egress field
+    egress:: [],
   },
 };
 

--- a/tests/golden/cilium/networkpolicy/networkpolicy/10_default_networkpolicies.yaml
+++ b/tests/golden/cilium/networkpolicy/networkpolicy/10_default_networkpolicies.yaml
@@ -31,7 +31,6 @@ spec:
           name: allow-from-same-namespace
         name: allow-from-same-namespace
       spec:
-        egress: []
         ingress:
           - from:
               - podSelector: {}
@@ -60,7 +59,6 @@ spec:
           name: allow-from-other-namespaces
         name: allow-from-other-namespaces
       spec:
-        egress: []
         ingress:
           - from:
               - namespaceSelector:

--- a/tests/golden/defaults/networkpolicy/networkpolicy/10_default_networkpolicies.yaml
+++ b/tests/golden/defaults/networkpolicy/networkpolicy/10_default_networkpolicies.yaml
@@ -31,7 +31,6 @@ spec:
           name: allow-from-same-namespace
         name: allow-from-same-namespace
       spec:
-        egress: []
         ingress:
           - from:
               - podSelector: {}
@@ -50,7 +49,6 @@ spec:
           name: allow-from-other-namespaces
         name: allow-from-other-namespaces
       spec:
-        egress: []
         ingress:
           - from:
               - namespaceSelector:


### PR DESCRIPTION
Field `spec.egress` is optional, so it doesn't need to be present in the resources, if it's empty.

This commit ensures that we omit the field in the managed network policies.

Fixes #26




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
