### PR TITLE
Draft: Allow to define the allow-from-same-namespace podSelector

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -5,6 +5,8 @@ parameters:
     labels:
       noDefaults: network-policies.syn.tools/no-defaults
       purgeDefaults: network-policies.syn.tools/purge-defaults
+    allowFromSameNamespace:
+      podSelector: {}
     allowNamespaceLabels: []
     ignoredNamespaces: []
     networkPlugin: ''

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -53,7 +53,7 @@ local allowSameNamespace = kube.NetworkPolicy('allow-from-same-namespace') {
   spec+: {
     ingress: [ {
       from: [ {
-        podSelector: {},
+        podSelector: params.allowFromSameNamespace.podSelector,
       } ],
     } ],
     // Hide unused optional egress field

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -16,6 +16,26 @@ purgeDefaults: network-policies.syn.tools/purge-defaults
 
 Name of the labels to be used in other components.
 
+== `allowFromSameNamespace.podSelector`
+
+[horizontal]
+type:: dictionary
+default:: {}
+
+A comprehensive list of values that the podSelector object supports.
+For more information on the podSelector object, refer to the kubectl explain networkpolicy.spec.podSelector command.
+
+[source,yaml]
+----
+allowFromSameNamespace:
+  podSelector:
+    matchLabels:
+      io.cilium.k8s.policy.cluster: cluster1
+----
+
+In the given example, traffic will be permitted on a Cilium Cluster Mesh-enabled cluster only within the same local cluster network.
+By default, the {} selector allows traffic between pods of all Cilium Cluster Mesh-enabled clusters that share the same namespace name.
+
 == `allowNamespaceLabels`
 
 [horizontal]

--- a/tests/cilium.yml
+++ b/tests/cilium.yml
@@ -14,3 +14,8 @@ parameters:
     allowNamespaceLabels:
       - test.example.net/test-group: main
     networkPlugin: Cilium
+
+    allowFromSameNamespace:
+      podSelector:
+        matchLabels:
+          io.cilium.k8s.policy.cluster: cluster1

--- a/tests/golden/cilium/networkpolicy/networkpolicy/10_default_networkpolicies.yaml
+++ b/tests/golden/cilium/networkpolicy/networkpolicy/10_default_networkpolicies.yaml
@@ -33,7 +33,9 @@ spec:
       spec:
         ingress:
           - from:
-              - podSelector: {}
+              - podSelector:
+                  matchLabels:
+                    io.cilium.k8s.policy.cluster: cluster1
         podSelector: {}
         policyTypes:
           - Ingress


### PR DESCRIPTION
Using the Cilium Cluster Mesh allows traffic between pods of all Cilium Cluster Mesh-enabled clusters that share the same namespace name.

For some use cases this is not suitable.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
