### PR TITLE
Add support for isolating namespaces between clusters in Cilium cluster mesh

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -7,7 +7,7 @@
       "name": "NetworkPolicy",
       "slug": "networkpolicy",
       "parameter_key": "networkpolicy",
-      "test_cases": "defaults cilium",
+      "test_cases": "defaults cilium cilium-isolation",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",

--- a/.cruft.json
+++ b/.cruft.json
@@ -11,7 +11,7 @@
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",
-      "add_matrix": "n",
+      "add_matrix": "y",
       "add_go_unit": "n",
       "automerge_patch": "y",
       "automerge_patch_v0": "n",
@@ -24,7 +24,8 @@
       "github_owner": "projectsyn",
       "github_name": "component-networkpolicy",
       "github_url": "https://github.com/projectsyn/component-networkpolicy",
-      "_template": "https://github.com/projectsyn/commodore-component-template.git"
+      "_template": "https://github.com/projectsyn/commodore-component-template.git",
+      "_commit": "98d16f99766e6c6d97322dbe42e058f0e2bf73d0"
     }
   },
   "directory": null

--- a/.cruft.json
+++ b/.cruft.json
@@ -7,7 +7,7 @@
       "name": "NetworkPolicy",
       "slug": "networkpolicy",
       "parameter_key": "networkpolicy",
-      "test_cases": "defaults",
+      "test_cases": "defaults cilium",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,10 @@ jobs:
           args: 'check'
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        instance:
+          - defaults
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -37,9 +41,13 @@ jobs:
         with:
           path: ${{ env.COMPONENT_NAME }}
       - name: Compile component
-        run: make test
+        run: make test -e instance=${{ matrix.instance }}
   golden:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        instance:
+          - defaults
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -48,4 +56,4 @@ jobs:
         with:
           path: ${{ env.COMPONENT_NAME }}
       - name: Golden diff
-        run: make golden-diff
+        run: make golden-diff -e instance=${{ matrix.instance }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,7 @@ jobs:
         instance:
           - defaults
           - cilium
+          - cilium-isolation
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -50,6 +51,7 @@ jobs:
         instance:
           - defaults
           - cilium
+          - cilium-isolation
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         instance:
           - defaults
+          - cilium
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -48,6 +49,7 @@ jobs:
       matrix:
         instance:
           - defaults
+          - cilium
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,22 @@ golden-diff: commodore_args += -f tests/$(instance).yml
 golden-diff: clean .compile ## Diff compile output against the reference version. Review output and run `make gen-golden golden-diff` if this target fails.
 	@git diff --exit-code --minimal --no-index -- tests/golden/$(instance) compiled/
 
+.PHONY: golden-diff-all
+golden-diff-all: recursive_target=golden-diff
+golden-diff-all: $(test_instances) ## Run golden-diff for all instances. Note: this doesn't work when running make with multiple parallel jobs (-j != 1).
+
+.PHONY: gen-golden-all
+gen-golden-all: recursive_target=gen-golden
+gen-golden-all: $(test_instances) ## Run gen-golden for all instances. Note: this doesn't work when running make with multiple parallel jobs (-j != 1).
+
+.PHONY: lint_kubent_all
+lint_kubent_all: recursive_target=lint_kubent
+lint_kubent_all: $(test_instances) ## Lint deprecated Kubernetes API versions for all golden test instances. Will exit on first error. Note: this doesn't work when running make with multiple parallel jobs (-j != 1).
+
+.PHONY: $(test_instances)
+$(test_instances):
+	$(MAKE) $(recursive_target) -e instance=$(basename $(@F))
+
 .PHONY: clean
 clean: ## Clean the project
 	rm -rf .cache compiled dependencies vendor helmcharts jsonnetfile*.json || true

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,3 +57,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
+test_instances = tests/defaults.yml

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,4 +57,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml
+test_instances = tests/defaults.yml tests/cilium.yml

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,4 +57,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/cilium.yml
+test_instances = tests/defaults.yml tests/cilium.yml tests/cilium-isolation.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -8,3 +8,4 @@ parameters:
     allowNamespaceLabels: []
     ignoredNamespaces: []
     networkPlugin: ''
+    ciliumClusterID: ''

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -61,6 +61,29 @@ This needs to be set when using the Cilium network plugin.
 Otherwise some policies might not be applied correctly.
 ====
 
+== `ciliumClusterID`
+
+[horizontal]
+type:: string
+default:: `''`
+
+This parameter controls whether the component isolates namespaces with the same name from each other in a Cilium cluster mesh.
+The default behavior if the parameter is empty is to allow connectivity between namespaces with the same name across clusters.
+
+If this behavior isn't desired, this parameter can be set to the cluster's Cilium cluster ID (which is configured in parameter `cilium.cilium_helm_values.cluster.name` when using cluster mesh).
+When the parameter isn't empty, the component will adjust the `allow-from-same-namespace` policy with the following snippet:
+
+[source,yaml]
+----
+spec:
+ ingress:
+ - from:
+   - podSelector:
+       matchLabels:
+         io.cilium.k8s.policy.cluster: <ciliumClusterID> <1>
+----
+<1> `<ciliumClusterID>` is replaced with the string provided in this parameter
+
 == Example
 
 [source,yaml]

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
   "separateMinorPatch": true,
   "postUpgradeTasks": {
     "commands": [
-      "make gen-golden"
+      "make gen-golden-all"
     ],
     "fileFilters": [
       "tests/golden/**"

--- a/tests/cilium-isolation.yml
+++ b/tests/cilium-isolation.yml
@@ -1,0 +1,17 @@
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-espejo/v1.0.1/lib/espejo.libsonnet
+        output_path: vendor/lib/espejo.libsonnet
+
+  espejo:
+    namespace: espejo
+
+  networkpolicy:
+    ignoredNamespaces:
+      - my-ignored-namespace
+    allowNamespaceLabels:
+      - test.example.net/test-group: main
+    networkPlugin: Cilium
+    ciliumClusterID: ${cluster:name}

--- a/tests/golden/cilium-isolation/networkpolicy/networkpolicy/05_purge_defaults.yaml
+++ b/tests/golden/cilium-isolation/networkpolicy/networkpolicy/05_purge_defaults.yaml
@@ -1,0 +1,54 @@
+apiVersion: sync.appuio.ch/v1alpha1
+kind: SyncConfig
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    syn.tools/source: https://github.com/projectsyn/component-networkpolicy.git
+  labels:
+    app.kubernetes.io/component: networkpolicy
+    app.kubernetes.io/part-of: syn
+    name: networkpolicies-purge-defaults-ignored-namespaces
+  name: networkpolicies-purge-defaults-ignored-namespaces
+  namespace: espejo
+spec:
+  deleteItems:
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      name: allow-from-same-namespace
+    - apiVersion: cilium.io/v2
+      kind: CiliumNetworkPolicy
+      name: allow-from-cluster-nodes
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      name: allow-from-other-namespaces
+  namespaceSelector:
+    matchNames:
+      - my-ignored-namespace
+---
+apiVersion: sync.appuio.ch/v1alpha1
+kind: SyncConfig
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    syn.tools/source: https://github.com/projectsyn/component-networkpolicy.git
+  labels:
+    app.kubernetes.io/component: networkpolicy
+    app.kubernetes.io/part-of: syn
+    name: networkpolicies-purge-defaults-by-label
+  name: networkpolicies-purge-defaults-by-label
+  namespace: espejo
+spec:
+  deleteItems:
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      name: allow-from-same-namespace
+    - apiVersion: cilium.io/v2
+      kind: CiliumNetworkPolicy
+      name: allow-from-cluster-nodes
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      name: allow-from-other-namespaces
+  namespaceSelector:
+    labelSelector:
+      matchLabels:
+        network-policies.syn.tools/purge-defaults: 'true'

--- a/tests/golden/cilium-isolation/networkpolicy/networkpolicy/10_default_networkpolicies.yaml
+++ b/tests/golden/cilium-isolation/networkpolicy/networkpolicy/10_default_networkpolicies.yaml
@@ -1,0 +1,71 @@
+apiVersion: sync.appuio.ch/v1alpha1
+kind: SyncConfig
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    syn.tools/source: https://github.com/projectsyn/component-networkpolicy.git
+  labels:
+    app.kubernetes.io/component: networkpolicy
+    app.kubernetes.io/part-of: syn
+    name: networkpolicies-default
+  name: networkpolicies-default
+  namespace: espejo
+spec:
+  namespaceSelector:
+    ignoreNames:
+      - my-ignored-namespace
+    labelSelector:
+      matchExpressions:
+        - key: network-policies.syn.tools/no-defaults
+          operator: DoesNotExist
+  syncItems:
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        annotations:
+          syn.tools/source: https://github.com/projectsyn/component-networkpolicy.git
+        labels:
+          app.kubernetes.io/component: networkpolicy
+          app.kubernetes.io/managed-by: espejo
+          app.kubernetes.io/part-of: syn
+          name: allow-from-same-namespace
+        name: allow-from-same-namespace
+      spec:
+        ingress:
+          - from:
+              - podSelector:
+                  matchLabels:
+                    io.cilium.k8s.policy.cluster: c-green-test-1234
+        podSelector: {}
+        policyTypes:
+          - Ingress
+    - apiVersion: cilium.io/v2
+      kind: CiliumNetworkPolicy
+      metadata:
+        name: allow-from-cluster-nodes
+      spec:
+        endpointSelector: {}
+        ingress:
+          - fromEntities:
+              - host
+              - remote-node
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        annotations:
+          syn.tools/source: https://github.com/projectsyn/component-networkpolicy.git
+        labels:
+          app.kubernetes.io/component: networkpolicy
+          app.kubernetes.io/managed-by: espejo
+          app.kubernetes.io/part-of: syn
+          name: allow-from-other-namespaces
+        name: allow-from-other-namespaces
+      spec:
+        ingress:
+          - from:
+              - namespaceSelector:
+                  matchLabels:
+                    test.example.net/test-group: main
+        podSelector: {}
+        policyTypes:
+          - Ingress


### PR DESCRIPTION
We add a new parameter `ciliumClusterID` that controls whether to isolate namespaces with the same name in a Cilium cluster mesh from each other. When the parameter isn't the empty string, the component updates the `allow-from-same-namespace` policy to only allow traffic within the namespace from workloads with Cilium policy label `io.cilium.k8s.policy.cluster=<ciliumClusterID>`.

By default the component will not isolate namespaces with the same name from each other when installed on a cluster that's part of a Cilium cluster mesh.

Replaces #51 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
