### PR TITLE
Support restricting the `allow-from-cluster-nodes` Cilium network policy

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -9,3 +9,4 @@ parameters:
     ignoredNamespaces: []
     networkPlugin: ''
     ciliumClusterID: ''
+    allowFromNodeLabels: {}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -84,6 +84,42 @@ spec:
 ----
 <1> `<ciliumClusterID>` is replaced with the string provided in this parameter
 
+== `allowFromNodeLabels`
+
+[horizontal]
+type:: dict
+default:: `{}`
+
+This parameter allows users to customize the `allow-from-cluster-nodes` `CiliumNetworkPolicy`.
+
+When this parameter is empty, this policy allow access from workloads running on all cluster nodes (including nodes of other clusters in the same cluster mesh) to workloads.
+This ensures that -- for example -- an ingress controller which is running in host-network mode can access workloads that are exposed through an `Ingress`.
+
+When the parameter isn't empty, the component uses the contents as the value for `matchLabels` in a `fromNodes` entry in the `CiliumNetworkPolicy`.
+This restricts access to workloads to the host network on nodes matching the provided label selector(s).
+See the https://docs.cilium.io/en/latest/security/policy/language/#node-based[Cilium documentation] for details on the `fromNodes` policy mechanism.
+
+IMPORTANT: When setting a value for this parameter, you must ensure that you're using Cilium 1.16 or newer and that the Helm value `nodeSelectorLabels=true` is set for your Cilium installation.
+
+[NOTE]
+====
+The `allow-from-cluster-nodes` policy always allows access to workloads in the namespace from the host on which they're running.
+This ensures that the Kubernetes health checks work as expected regardless of the provided label selector.
+====
+
+[TIP]
+====
+For isolating access to workloads between clusters in a Cilium cluster mesh, you can label all nodes of each cluster with the cluster's Project Syn ID, for example with `kubectl label nodes --all syn.tools/cluster-id=c-the-cluster-1234`.
+
+Then you can set this parameter as
+
+[source,yaml]
+----
+allowFromNodeLabels:
+  syn.tools/cluster-id: ${cluster:name}
+----
+====
+
 == Example
 
 [source,yaml]

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -1,2 +1,2 @@
 * xref:index.adoc[Home]
-xref:references/parameters.adoc[Parameters]
+* xref:references/parameters.adoc[Parameters]

--- a/tests/cilium-isolation.yml
+++ b/tests/cilium-isolation.yml
@@ -15,3 +15,5 @@ parameters:
       - test.example.net/test-group: main
     networkPlugin: Cilium
     ciliumClusterID: ${cluster:name}
+    allowFromNodeLabels:
+      syn.tools/cluster-id: ${cluster:name}

--- a/tests/golden/cilium-isolation/networkpolicy/networkpolicy/10_default_networkpolicies.yaml
+++ b/tests/golden/cilium-isolation/networkpolicy/networkpolicy/10_default_networkpolicies.yaml
@@ -48,7 +48,9 @@ spec:
         ingress:
           - fromEntities:
               - host
-              - remote-node
+          - fromNodes:
+              - matchLabels:
+                  syn.tools/cluster-id: c-green-test-1234
     - apiVersion: networking.k8s.io/v1
       kind: NetworkPolicy
       metadata:


### PR DESCRIPTION
We introduce a new parameter `allowFromNodeLabels` which can be used to customize the `allow-from-cluster-nodes` CiliumNetworkPolicy. By default, the component deploys a permissive policy that allows access to workloads from all cluster nodes (also across clusters in a cluster-mesh setup).

By setting the parameter, and enabling Cilium's `nodeSelectorLabels` policy feature (Cilium 1.16 and newer), it's possible to restrict access to workloads to a subset of nodes in the cluster based on their labels.

Follow-up to #52 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
